### PR TITLE
给定文档“CBD”,匹配搜索c,b,d,cb,cbd

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Lc Pinyin版本
 
 LC version | ES version
 -----------|-----------
-master | 5.3.0 -> master
+master | 5.4.0 -> master
 5.3.0.1 | 5.3.0
 5.2.2.1 | 5.2.2
 5.2.0.1 | 5.2.0
@@ -402,6 +402,12 @@ QueryBuilder pinyinQueryBuilder =  QueryBuilders.matchPhraseQuery("name", "dzdp"
                 .addHighlightedField("name")
                 .execute().actionGet();
 ```
+
+------
+## 自动提示的例子
+以下是使用lc_index分析器结合edgeNgram TokenFilter实现自动提示的例子：
+* [例子](examples/suggest%20example.txt) 
+
 作者:  [@陈楠][1]
 Email: 465360798@qq.com
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Lc Pinyin版本
 
 LC version | ES version
 -----------|-----------
-master | 5.4.0 -> master
+master | 5.5.1 -> master
 5.3.0.1 | 5.3.0
 5.2.2.1 | 5.2.2
 5.2.0.1 | 5.2.0

--- a/examples/suggest example.txt
+++ b/examples/suggest example.txt
@@ -1,0 +1,188 @@
+﻿GET /_cat/indices
+
+DELETE /test_index
+
+PUT /test_index
+{
+  "settings" : {
+    "number_of_shards" : 1,
+    "number_of_replicas" : 0,
+    "analysis" : {
+      "analyzer" : {
+        "lc_index_ngram" : {
+          "tokenizer" : "lc_index",
+          "filter" : ["lowercase","my_edge_ngram_tokenizer"]
+        }
+      },
+      "filter" :{
+        "my_edge_ngram_tokenizer" : {
+          "type" : "edgeNGram",
+          "min_gram" : "1",
+          "max_gram" : "6",
+          "token_chars": ["letter", "digit"]
+        }
+      }
+    }
+  }
+}
+
+POST /test_index/_mapping/brand
+{
+  "brand": {
+    "properties": {
+      "name": {
+        "type": "text",
+        "analyzer": "lc_index_ngram",
+        "search_analyzer": "lc_search",
+        "term_vector": "with_positions_offsets"
+      }
+    }
+  }
+}
+
+POST /test_index/brand/11
+{"name":"刘德华"}
+
+POST /test_index/brand/12
+{"name":"刘斌"}
+
+POST /test_index/brand/13
+{"name":"张三"}
+
+POST /test_index/brand/14
+{"name":"李四"}
+
+POST /test_index/brand/15
+{"name":"刘德志"}
+
+POST /test_index/brand/16
+{"name":"CBD"}
+
+POST /test_index/brand/17
+{"name":"T2"}
+
+### # 中文搜索: 搜索的文字需要匹配到集合中所有名字的子集。
+### #   1、搜索“刘”，匹配到“刘德华”、“刘斌”、“刘德志”
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "刘","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+### #   2、搜索“刘德”，匹配到“刘德华”、“刘德志”
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "刘德","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+### #   3、搜索“德华”，匹配到“刘德华”
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "德华","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+
+### #拼音搜索：搜索的文字转换成拼音后，需要匹配到集合中所有名字转成拼音后的子集
+### #   1、搜索“liu”，匹配到“刘德华”、“刘斌”、“刘德志”
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "liu","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+### #   2、搜索“liude”，匹配到“刘德华”、“刘德志”
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "liude","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+### #   3、搜索“liudehua”或“ldh”，匹配到“刘德华”
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "liudehua","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "ldh","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+
+### #   4、搜索lidh liudh ldeh ldehu ldehua lideh liudeh liudhua 等等缺一两个拼音字母的，也可以匹配到“刘德华”
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "lidh","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "liudh","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "ldeh","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "ldehu","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "ldehua","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "lideh","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "liudeh","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "liudhu","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "liudhua","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "lidehua","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+### #   4、搜索l ld d dh h li liu de hu hua 等等缺一两个拼音字母的单字，也可以匹配到“刘德华”
+
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "l","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "ld","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "d","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "dh","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "h","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "li","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "liu","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "de","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "hu","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "hua","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+### # 5、搜索c cb cbd bd
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "c","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "cb","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "cbd","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+POST /test_index/brand/_search?pretty
+{"query": {"match_phrase": {"name": {"query": "bd","analyzer": "lc_search"}}},"highlight" : {"pre_tags" : ["<tag1>"],"post_tags" : ["</tag1>"],"fields" : {"name" : {}}}}
+
+
+
+GET /test_index/brand/16
+
+GET /test_index/_analyze
+{"text" : "T2","analyzer": "lc_index"}
+GET /test_index/_analyze
+{"text" : "CBD","analyzer": "lc_index_ngram"}
+GET /test_index/_analyze
+{"text" : "cbd","analyzer": "lc_search"}
+
+GET /test_index/_analyze
+{"text" : "T2","tokenizer": "lc_index"}
+GET /test_index/_analyze
+{"text" : "T2","analyzer": "lc_index_ngram"}
+GET /test_index/_analyze
+{"text" : "t2","analyzer": "lc_search"}
+

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     </licenses>
 
     <properties>
-        <elasticsearch.version>5.3.0</elasticsearch.version>
+        <elasticsearch.version>5.4.0</elasticsearch.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <elasticsearch.assembly.descriptor>${project.basedir}/src/main/assemblies/plugin.xml</elasticsearch.assembly.descriptor>
         <elasticsearch.plugin.name>analysis-lc-pinyin</elasticsearch.plugin.name>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     </licenses>
 
     <properties>
-        <elasticsearch.version>5.4.0</elasticsearch.version>
+        <elasticsearch.version>5.5.1</elasticsearch.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <elasticsearch.assembly.descriptor>${project.basedir}/src/main/assemblies/plugin.xml</elasticsearch.assembly.descriptor>
         <elasticsearch.plugin.name>analysis-lc-pinyin</elasticsearch.plugin.name>

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
                 <version>2.11</version>
                 <configuration>
                     <includes>
-                        <include>**/*Tests.java</include>
+                        <include>**/*Test.java</include>
                     </includes>
                 </configuration>
             </plugin>

--- a/src/main/java/org/lc/core/LcPinyinIndexSegmenter.java
+++ b/src/main/java/org/lc/core/LcPinyinIndexSegmenter.java
@@ -36,9 +36,9 @@ public class LcPinyinIndexSegmenter extends AbstractPinyinSegmenter {
         } else {
             int charType = CharacterUtil.identifyCharType(CharacterUtil.regularize(ch));
             lexemeList.add(new Lexeme(getOffset(), token.length(), token.length(), 1, charType, token));
-            if (CharacterUtil.CHAR_ARABIC.equals(charType) || (CharacterUtil.CHAR_ENGLISH.equals(charType)) {
+            if (token.length() > 1 && (CharacterUtil.CHAR_ARABIC == charType || CharacterUtil.CHAR_ENGLISH == charType)) {
                 for (int idx = 0; idx < token.length(); idx++) {
-                    Lexeme tmpLexeme = new Lexeme(getOffset()+idx, 1, 1, 0, charType, token.charAt(idx) + "");
+                    Lexeme tmpLexeme = new Lexeme(getOffset() + idx, 1, 1, 1, charType, token.charAt(idx) + "");
                     lexemeList.add(tmpLexeme);
                 }
             }

--- a/src/main/java/org/lc/core/LcPinyinIndexSegmenter.java
+++ b/src/main/java/org/lc/core/LcPinyinIndexSegmenter.java
@@ -36,6 +36,12 @@ public class LcPinyinIndexSegmenter extends AbstractPinyinSegmenter {
         } else {
             int charType = CharacterUtil.identifyCharType(CharacterUtil.regularize(ch));
             lexemeList.add(new Lexeme(getOffset(), token.length(), token.length(), 1, charType, token));
+            if (CharacterUtil.CHAR_ARABIC.equals(charType) || (CharacterUtil.CHAR_ENGLISH.equals(charType)) {
+                for (int idx = 0; idx < token.length(); idx++) {
+                    Lexeme tmpLexeme = new Lexeme(getOffset()+idx, 1, 1, 0, charType, token.charAt(idx) + "");
+                    lexemeList.add(tmpLexeme);
+                }
+            }
             incrementOffset(token.length());
         }
         return lexemeList;

--- a/src/main/java/org/lc/lucene/AbstractLcPinyinTokenizer.java
+++ b/src/main/java/org/lc/lucene/AbstractLcPinyinTokenizer.java
@@ -19,7 +19,7 @@ public abstract class AbstractLcPinyinTokenizer extends Tokenizer {
     protected abstract ISegmenter getSegmenter();
 
     @Override
-    public boolean incrementToken() throws IOException {
+    public final boolean incrementToken() throws IOException {
         clearAttributes();
         Lexeme lexeme = getSegmenter().next();
         if (lexeme != null) {

--- a/src/main/java/org/lc/lucene/LcPinyinTokenFilter.java
+++ b/src/main/java/org/lc/lucene/LcPinyinTokenFilter.java
@@ -27,7 +27,7 @@ public class LcPinyinTokenFilter extends TokenFilter {
     }
 
     @Override
-    public boolean incrementToken() throws IOException {
+    public final boolean incrementToken() throws IOException {
         if (hasMoreTokenInCache()) {
             this.termAtt.setEmpty();
             this.termAtt.append(nextTokenLexeme());

--- a/src/main/java/org/lc/lucene/UselessCharFilter.java
+++ b/src/main/java/org/lc/lucene/UselessCharFilter.java
@@ -16,7 +16,7 @@ public class UselessCharFilter extends TokenFilter {
     }
 
     @Override
-    public boolean incrementToken() throws IOException {
+    public final boolean incrementToken() throws IOException {
         while (this.input.incrementToken()) {
             char[] text = this.termAtt.buffer();
             int termLength = this.termAtt.length();

--- a/src/test/java/org/elasticsearch/LetterNumberAnalysisTest.java
+++ b/src/test/java/org/elasticsearch/LetterNumberAnalysisTest.java
@@ -1,0 +1,119 @@
+package org.elasticsearch;
+
+
+import junit.framework.TestCase;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
+import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
+import org.junit.Assert;
+import org.junit.Test;
+import org.lc.core.AnalysisSetting;
+import org.lc.core.DfsPinyinSeg;
+import org.lc.core.PinyinDic;
+import org.lc.lucene.LcPinyinAnalyzer;
+
+import java.io.IOException;
+import java.util.List;
+
+public class LetterNumberAnalysisTest extends TestCase {
+    @Test
+    public void testIndexTokenizer() throws IOException {
+        LcPinyinAnalyzer analyzer = new LcPinyinAnalyzer(AnalysisSetting.index, AnalysisSetting.IndexAnalysisSetting.full_pinyin | AnalysisSetting.IndexAnalysisSetting.first_letter);
+        TokenStream tokenStream = analyzer.tokenStream("lc", "CBD123");
+
+        CharTermAttribute charTermAttribute = tokenStream.getAttribute(CharTermAttribute.class);
+        OffsetAttribute offsetAttribute = tokenStream.getAttribute(OffsetAttribute.class);
+        PositionIncrementAttribute positionIncrementAttribute = tokenStream.getAttribute(PositionIncrementAttribute.class);
+
+        tokenStream.reset();
+        Assert.assertTrue(tokenStream.incrementToken());
+        Assert.assertEquals(charTermAttribute.toString(), "cbd");
+        Assert.assertEquals(offsetAttribute.startOffset(), 0);
+        Assert.assertEquals(offsetAttribute.endOffset(), 3);
+        Assert.assertEquals(positionIncrementAttribute.getPositionIncrement(), 1);
+
+        Assert.assertTrue(tokenStream.incrementToken());
+        Assert.assertEquals(charTermAttribute.toString(), "c");
+        Assert.assertEquals(offsetAttribute.startOffset(), 0);
+        Assert.assertEquals(offsetAttribute.endOffset(), 1);
+        Assert.assertEquals(positionIncrementAttribute.getPositionIncrement(), 1);
+
+        Assert.assertTrue(tokenStream.incrementToken());
+        Assert.assertEquals(charTermAttribute.toString(), "b");
+        Assert.assertEquals(offsetAttribute.startOffset(), 1);
+        Assert.assertEquals(offsetAttribute.endOffset(), 2);
+        Assert.assertEquals(positionIncrementAttribute.getPositionIncrement(), 1);
+
+        Assert.assertTrue(tokenStream.incrementToken());
+        Assert.assertEquals(charTermAttribute.toString(), "d");
+        Assert.assertEquals(offsetAttribute.startOffset(), 2);
+        Assert.assertEquals(offsetAttribute.endOffset(), 3);
+        Assert.assertEquals(positionIncrementAttribute.getPositionIncrement(), 1);
+
+        Assert.assertTrue(tokenStream.incrementToken());
+        Assert.assertEquals(charTermAttribute.toString(), "123");
+        Assert.assertEquals(offsetAttribute.startOffset(), 3);
+        Assert.assertEquals(offsetAttribute.endOffset(), 6);
+        Assert.assertEquals(positionIncrementAttribute.getPositionIncrement(), 1);
+
+        Assert.assertTrue(tokenStream.incrementToken());
+        Assert.assertEquals(charTermAttribute.toString(), "1");
+        Assert.assertEquals(offsetAttribute.startOffset(), 3);
+        Assert.assertEquals(offsetAttribute.endOffset(), 4);
+        Assert.assertEquals(positionIncrementAttribute.getPositionIncrement(), 1);
+
+        Assert.assertTrue(tokenStream.incrementToken());
+        Assert.assertEquals(charTermAttribute.toString(), "2");
+        Assert.assertEquals(offsetAttribute.startOffset(), 4);
+        Assert.assertEquals(offsetAttribute.endOffset(), 5);
+        Assert.assertEquals(positionIncrementAttribute.getPositionIncrement(), 1);
+
+        Assert.assertTrue(tokenStream.incrementToken());
+        Assert.assertEquals(charTermAttribute.toString(), "3");
+        Assert.assertEquals(offsetAttribute.startOffset(), 5);
+        Assert.assertEquals(offsetAttribute.endOffset(), 6);
+        Assert.assertEquals(positionIncrementAttribute.getPositionIncrement(), 1);
+
+        tokenStream.close();
+    }
+
+    @Test
+    public void testSearch() throws IOException {
+        LcPinyinAnalyzer analyzer = new LcPinyinAnalyzer(AnalysisSetting.search);
+        TokenStream tokenStream = analyzer.tokenStream("lc", "CBD123");
+
+        CharTermAttribute charTermAttribute = tokenStream.getAttribute(CharTermAttribute.class);
+        OffsetAttribute offsetAttribute = tokenStream.getAttribute(OffsetAttribute.class);
+        PositionIncrementAttribute positionIncrementAttribute = tokenStream.getAttribute(PositionIncrementAttribute.class);
+
+        tokenStream.reset();
+
+        Assert.assertTrue(tokenStream.incrementToken());
+        Assert.assertEquals(charTermAttribute.toString(), "c");
+        Assert.assertEquals(offsetAttribute.startOffset(), 0);
+        Assert.assertEquals(offsetAttribute.endOffset(), 1);
+        Assert.assertEquals(positionIncrementAttribute.getPositionIncrement(), 1);
+
+        Assert.assertTrue(tokenStream.incrementToken());
+        Assert.assertEquals(charTermAttribute.toString(), "b");
+        Assert.assertEquals(offsetAttribute.startOffset(), 1);
+        Assert.assertEquals(offsetAttribute.endOffset(), 2);
+        Assert.assertEquals(positionIncrementAttribute.getPositionIncrement(), 1);
+
+        Assert.assertTrue(tokenStream.incrementToken());
+        Assert.assertEquals(charTermAttribute.toString(), "d");
+        Assert.assertEquals(offsetAttribute.startOffset(), 2);
+        Assert.assertEquals(offsetAttribute.endOffset(), 3);
+        Assert.assertEquals(positionIncrementAttribute.getPositionIncrement(), 1);
+
+        Assert.assertTrue(tokenStream.incrementToken());
+        Assert.assertEquals(charTermAttribute.toString(), "123");
+        Assert.assertEquals(offsetAttribute.startOffset(), 3);
+        Assert.assertEquals(offsetAttribute.endOffset(), 6);
+        Assert.assertEquals(positionIncrementAttribute.getPositionIncrement(), 1);
+
+        tokenStream.close();
+    }
+
+}

--- a/src/test/java/org/elasticsearch/LetterNumberFilterTest.java
+++ b/src/test/java/org/elasticsearch/LetterNumberFilterTest.java
@@ -1,0 +1,51 @@
+package org.elasticsearch;
+
+import junit.framework.TestCase;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
+import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
+import org.lc.core.AnalysisSetting;
+import org.lc.core.PinyinFilterSetting;
+import org.lc.lucene.LcPinyinAnalyzer;
+import org.lc.lucene.LcPinyinTokenFilter;
+
+import java.io.IOException;
+
+public class LetterNumberFilterTest extends TestCase {
+    public void testFullPinyinFilter() throws IOException {
+
+        LcPinyinAnalyzer analyzer = new LcPinyinAnalyzer(AnalysisSetting.search);
+        TokenStream tokenStream = analyzer.tokenStream("lc", "CBD123");
+
+        LcPinyinTokenFilter lcPinyinTokenFilter = new LcPinyinTokenFilter(tokenStream, PinyinFilterSetting.full_pinyin);
+
+        CharTermAttribute charTermAttribute = lcPinyinTokenFilter.getAttribute(CharTermAttribute.class);
+        OffsetAttribute offsetAttribute = lcPinyinTokenFilter.getAttribute(OffsetAttribute.class);
+        PositionIncrementAttribute positionIncrementAttribute = lcPinyinTokenFilter.getAttribute(PositionIncrementAttribute.class);
+
+        lcPinyinTokenFilter.reset();
+        while (lcPinyinTokenFilter.incrementToken()) {
+            System.out.println(charTermAttribute.toString() + ":" + offsetAttribute.startOffset() + "," + offsetAttribute.endOffset() + ":" + positionIncrementAttribute.getPositionIncrement());
+        }
+        lcPinyinTokenFilter.close();
+    }
+
+    public void testFirstLetterFilter() throws IOException {
+
+        LcPinyinAnalyzer analyzer = new LcPinyinAnalyzer(AnalysisSetting.search);
+        TokenStream tokenStream = analyzer.tokenStream("lc", "CBD123");
+
+        LcPinyinTokenFilter lcPinyinTokenFilter = new LcPinyinTokenFilter(tokenStream, PinyinFilterSetting.first_letter);
+
+        CharTermAttribute charTermAttribute = lcPinyinTokenFilter.getAttribute(CharTermAttribute.class);
+        OffsetAttribute offsetAttribute = lcPinyinTokenFilter.getAttribute(OffsetAttribute.class);
+        PositionIncrementAttribute positionIncrementAttribute = lcPinyinTokenFilter.getAttribute(PositionIncrementAttribute.class);
+
+        lcPinyinTokenFilter.reset();
+        while (lcPinyinTokenFilter.incrementToken()) {
+            System.out.println(charTermAttribute.toString() + ":" + offsetAttribute.startOffset() + "," + offsetAttribute.endOffset() + ":" + positionIncrementAttribute.getPositionIncrement());
+        }
+        lcPinyinTokenFilter.close();
+    }
+}


### PR DESCRIPTION
lc-pinyin分析器很强大，我们在搜索框自动提示中用着很爽。感谢作者分享！
不过，在处理中英文混合文档或者纯英文、数字时，我们遇到一个小问题，希望得到改进：
使用lc_index分析器索引文档“CBD”，然后使用lc_search分析器构建match_phrase查询，搜索“CBD” ，无法匹配。
经过反复测试，发现对于英文单词和数字，lc_index 分析器默认不会切分成单字符，比如“CBD”经分析后还是"CBD"，而lc_search默认会切分成单字符搜索，比如“CBD”经分析后变成了“C” "B" "D"，这样就搜不到结果了。 因此我们尝试修改lc_index生成token的过程，让输入“CBD”输出“CBD” “C” “B” “D”，这样可以解决搜不到的问题。 希望能够合并代码，并加以优化：把单词拆成单个字符的功能做成一个开关，供有需要的人使用。谢谢！